### PR TITLE
Raise the palette window when its mapped

### DIFF
--- a/src/sugar/graphics/palette.py
+++ b/src/sugar/graphics/palette.py
@@ -138,6 +138,11 @@ class Palette(PaletteWindow):
         self.connect('hide', self.__hide_cb)
         self.connect('notify::invoker', self.__notify_invoker_cb)
         self.connect('destroy', self.__destroy_cb)
+        self.connect('map', self.__map_cb)
+
+    def __map_cb(self, *args):
+        # Fixes #4463
+        self.present()
 
     def _invoker_right_click_cb(self, invoker):
         self.popup(immediate=True, state=self.SECONDARY)


### PR DESCRIPTION
This patch raise the palette window when its mapped
Its use: Gtk.Window.present [1] the user will
be able to saw the palette now when your apply the
test case of #4463

[1] http://pygtk.org/pygtk2reference/class-gtkwindow.html#method-gtkwindow--present
Fixes #4463
