### PR TITLE
SaveAs Pop on Activity Close

### DIFF
--- a/src/sugar/activity/Makefile.am
+++ b/src/sugar/activity/Makefile.am
@@ -5,6 +5,7 @@ sugar_PYTHON =              \
 	activityfactory.py      \
 	activityhandle.py       \
 	activityservice.py      \
+	alerts.py               \
 	bundlebuilder.py        \
 	i18n.py			\
 	widgets.py

--- a/src/sugar/activity/activity.py
+++ b/src/sugar/activity/activity.py
@@ -75,6 +75,7 @@ from sugar.profile import get_color
 from sugar.presence import presenceservice
 from sugar.activity import i18n
 from sugar.activity.activityservice import ActivityService
+from sugar.activity.alerts import SaveAlert
 from sugar.graphics import style
 from sugar.graphics.window import Window
 from sugar.graphics.alert import Alert
@@ -312,6 +313,10 @@ class Activity(Window, gtk.Container):
         self._max_participants = 0
         self._invites_queue = []
         self._jobject = None
+        self._jobject_clone = None
+        self._pre_naming = False
+        self._is_resumed = False
+        self._save_alert = None
         self._read_file_called = False
 
         self._session = _get_session()
@@ -345,9 +350,23 @@ class Activity(Window, gtk.Container):
         self.shared_activity = None
         self._join_id = None
 
+        # This part is responsible for cloning the _jobject
         if handle.object_id is None and create_jobject:
             logging.debug('Creating a jobject.')
             self._jobject = self._initialize_journal_object()
+            self._is_resumed = False
+            self.set_title(self._jobject.metadata['title'])
+
+        elif gconf.client_get_default().get_bool("/desktop/sugar/user/save_as"):
+            self._is_resumed = True
+            logging.debug('Creating a jobject clone')
+            self._file_path = self._jobject.file_path
+            self._jobject_clone = self._jobject
+            self._jobject = self._initialize_journal_object()
+            self._jobject.file_path = self._file_path
+            self.set_title(self._jobject_clone.metadata['title'])
+
+        self._jobject_clone_title = self._jobject.metadata['title']
 
         if handle.invited:
             wait_loop = gobject.MainLoop()
@@ -377,8 +396,17 @@ class Activity(Window, gtk.Container):
                                            self.__jobject_updated_cb)
         self.set_title(self._jobject.metadata['title'])
 
+        self.connect('key-press-event', self.__keypress_event_cb)
+
         bundle = get_bundle_instance(get_bundle_path())
         self.set_icon_from_file(bundle.get_icon())
+
+    def __keypress_event_cb(self, widget, event):
+        keyname = gtk.gdk.keyval_name(event.keyval)
+        if keyname == 'Escape':
+            if not self._save_alert is None:
+                self._save_alert.disconnect(self._save_as_hid)
+                self.remove_alert(self._save_alert)
 
     def run_main_loop(self):
         gtk.main()
@@ -877,6 +905,45 @@ class Activity(Window, gtk.Container):
 
         return True
 
+    def _show_saveas_alert(self):
+        self._save_alert = SaveAlert()
+        self._save_alert.props.title = _('Save As')
+        self._save_alert.props.msg = _('Provide the name for the project')
+        if self._is_resumed:
+            self._save_alert._name_entry.set_text(self._jobject_clone.metadata['title'])
+        else:
+            self._save_alert._name_entry.set_text(self._jobject.metadata['title'])
+        ok_icon = Icon(icon_name='dialog-ok')
+        self._save_alert.add_button(gtk.RESPONSE_OK,
+                                    _('Save'), ok_icon)
+        cancel_icon = Icon(icon_name='dialog-cancel')
+        can = self._save_alert.add_button(gtk.RESPONSE_CANCEL,
+                                          _('Quit'), cancel_icon)
+        self._save_as_hid = self._save_alert.connect('response',
+                                                     self.__save_response_cb)
+        self.add_alert(self._save_alert)
+        self._save_alert.show()
+
+    def __save_response_cb(self, alert, response_id):
+        self.remove_alert(alert)
+        if self._save_alert._name_entry.get_text() is '':
+            self._show_saveas_alert()
+            return
+
+        if response_id == gtk.RESPONSE_OK:
+            self._skip_save_datafiles = False
+            self._jobject.metadata[
+                'title'] = self._save_alert._name_entry.get_text()
+            self._post_alert_close()
+            return
+
+        if response_id == gtk.RESPONSE_CANCEL:
+            self._skip_save_datafiles = True
+            if self._is_resumed is True:
+                datastore.delete(self._jobject.get_object_id())
+            self._post_alert_close()
+            return
+
     def _prepare_close(self, skip_save=False):
         if not skip_save:
             try:
@@ -914,8 +981,37 @@ class Activity(Window, gtk.Container):
         if not self.can_close():
             return
 
+        _save_as_enabled = gconf.client_get_default() \
+            .get_bool("/desktop/sugar/user/save_as")
+
+        if _save_as_enabled:
+            self._alert_confirmation()
+
         self.window.set_cursor(gtk.gdk.Cursor(gtk.gdk.WATCH))
         self.emit('_closing')
+
+        if (self._pre_naming is True or not _save_as_enabled):
+            self._post_alert_close()
+
+    def _alert_confirmation(self):
+        '''
+        Displays the alert for user to provide the save name on close.
+        '''
+        if (self._jobject.metadata['title'] != self._jobject_clone_title):
+            self._skip_save_datafiles = False
+            self._pre_naming = True
+            return
+        else:
+            self._show_saveas_alert()
+            return False
+
+    def _post_alert_close(self):
+        print "post entered"
+        if gconf.client_get_default() \
+            .get_bool("/desktop/sugar/user/save_as"):
+            skip_save = self._skip_save_datafiles
+        else:
+            skip_save = False
 
         if not self._closing:
             if not self._prepare_close(skip_save):

--- a/src/sugar/activity/alerts.py
+++ b/src/sugar/activity/alerts.py
@@ -1,0 +1,37 @@
+import gtk
+
+from sugar.graphics.alert import Alert
+from sugar.graphics import style
+
+
+class SaveAlert(Alert):
+    """
+    Creates a alert popup to prompt the user to specify
+    a name for the project to be saved.
+    """
+    __gtype_name__ = 'SaveAsAlert'
+
+    def __init__(self, **kwargs):
+        Alert.__init__(self, **kwargs)
+        # Name entry box
+        self._name_view = gtk.EventBox()
+        self._name_view.show()
+
+        # Entry box
+        self._name_entry = gtk.Entry()
+        halign = gtk.Alignment(0, 0, 1, 0)
+        self._hbox.pack_start(halign, True, True, 0)
+        halign.add(self._name_view)
+        halign.show()
+
+        self._name_view.add(self._name_entry)
+        self._name_entry.show()
+
+        halign = gtk.Alignment(0, 0, 0, 0)
+        self._buttons_box = gtk.HButtonBox()
+        self._buttons_box.set_layout(gtk.BUTTONBOX_END)
+        self._buttons_box.set_spacing(style.DEFAULT_SPACING)
+        halign.add(self._buttons_box)
+        self._hbox.pack_start(halign, False, False, 0)
+        halign.show()
+        self.show_all()


### PR DESCRIPTION
This popup appears when an activity is closed.
It prompts the user to specify a name for the current instance on close. Should the user choose to discard the changes, the activity data gets trashed whereas the activity metadata gets saved.
Related to - https://github.com/sugarlabs/sugar-toolkit-gtk3/pull/327

![desktop-animation](https://cloud.githubusercontent.com/assets/6258810/16902433/daa12e82-4c7b-11e6-9f42-3d1b819ddd3c.gif)
