### PR TITLE
Assign icon to window regardless of environment.

### DIFF
--- a/src/sugar/activity/activity.py
+++ b/src/sugar/activity/activity.py
@@ -376,9 +376,8 @@ class Activity(Window, gtk.Container):
                                            self.__jobject_updated_cb)
         self.set_title(self._jobject.metadata['title'])
 
-        if 'SUGAR_VERSION' not in os.environ:
-            bundle = get_bundle_instance(get_bundle_path())
-            self.set_icon_from_file(bundle.get_icon())
+        bundle = get_bundle_instance(get_bundle_path())
+        self.set_icon_from_file(bundle.get_icon())
 
     def run_main_loop(self):
         gtk.main()


### PR DESCRIPTION
Makes Sugar Activities more standard.
