### PR TITLE
Don't crash if D-Bus method is not available

### DIFF
--- a/src/sugar/presence/presenceservice.py
+++ b/src/sugar/presence/presenceservice.py
@@ -92,6 +92,11 @@ class PresenceService(gobject.GObject):
                     if e.get_dbus_name() == name:
                         logging.debug("There's no shared activity with the id "
                                       "%s", activity_id)
+                    elif e.get_dbus_name() == \
+                         'org.freedesktop.DBus.Error.UnknownMethod':
+                        logging.warning(
+                            'Telepathy Account %r does not support '
+                            'Sugar collaboration', account_path)
                     else:
                         raise
                 else:


### PR DESCRIPTION
Without this patch, I always get this traceback when I try to run any gtk2 activity outside from Sugar shell:
```
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 215, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 48, in create_activity_instance
    activity = constructor(handle)
  File "/usr/share/sugar/activities/Domino.activity/dominoactivity.py", line 51, in __init__
    activity.Activity.__init__(self, handle, create_jobject=False)
  File "/usr/lib/python2.7/site-packages/sugar/activity/activity.py", line 363, in __init__
    warn_if_none=False)
  File "/usr/lib/python2.7/site-packages/sugar/presence/presenceservice.py", line 89, in get_activity
    dbus_interface=CONN_INTERFACE_ACTIVITY_PROPERTIES)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 70, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 651, in call_blocking
    message, timeout)
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.UnknownMethod: Method "GetActivity" with signature "s" on interface "org.laptop.Telepathy.ActivityProperties" doesn't exist
```