### PR TITLE
Use profile.get_nickname and get_color where possible

### DIFF
--- a/src/sugar/activity/activity.py
+++ b/src/sugar/activity/activity.py
@@ -71,6 +71,7 @@ from telepathy.constants import CONNECTION_HANDLE_TYPE_CONTACT
 from telepathy.constants import CONNECTION_HANDLE_TYPE_ROOM
 
 from sugar import util
+from sugar.profile import get_color
 from sugar.presence import presenceservice
 from sugar.activity import i18n
 from sugar.activity.activityservice import ActivityService
@@ -385,7 +386,7 @@ class Activity(Window, gtk.Container):
     def _initialize_journal_object(self):
         title = _('%s Activity') % get_bundle_name()
         client = gconf.client_get_default()
-        icon_color = client.get_string('/desktop/sugar/user/color')
+        icon_color = get_color().to_string()
 
         jobject = datastore.create()
         jobject.metadata['title'] = title

--- a/src/sugar/datastore/datastore.py
+++ b/src/sugar/datastore/datastore.py
@@ -34,6 +34,7 @@ import dbus.glib
 from sugar import env
 from sugar import mime
 from sugar import dispatch
+from sugar.profile import get_color
 
 DS_DBUS_SERVICE = 'org.laptop.sugar.DataStore'
 DS_DBUS_INTERFACE = 'org.laptop.sugar.DataStore'
@@ -234,7 +235,7 @@ class RawObject(object):
                 'mime_type': gio.content_type_guess(filename=file_path),
                 'activity': '',
                 'activity_id': '',
-                'icon-color': client.get_string('/desktop/sugar/user/color'),
+                'icon-color': get_color().to_string(),
                 'description': file_path,
                 }
 

--- a/src/sugar/presence/buddy.py
+++ b/src/sugar/presence/buddy.py
@@ -32,6 +32,7 @@ from telepathy.interfaces import CONNECTION, \
 from telepathy.constants import HANDLE_TYPE_CONTACT
 
 from sugar.presence.connectionmanager import get_connection_manager
+from sugar.profile import get_color, get_nick_name
 
 ACCOUNT_MANAGER_SERVICE = 'org.freedesktop.Telepathy.AccountManager'
 CONN_INTERFACE_BUDDY_INFO = 'org.laptop.Telepathy.BuddyInfo'
@@ -244,5 +245,5 @@ class Owner(BaseBuddy):
         BaseBuddy.__init__(self)
 
         client = gconf.client_get_default()
-        self.props.nick = client.get_string('/desktop/sugar/user/nick')
-        self.props.color = client.get_string('/desktop/sugar/user/color')
+        self.props.nick = get_nick_name()
+        self.props.color = get_color().to_string()

--- a/src/sugar/profile.py
+++ b/src/sugar/profile.py
@@ -69,8 +69,8 @@ class Profile(object):
 
     def is_valid(self):
         client = gconf.client_get_default()
-        nick = client.get_string('/desktop/sugar/user/nick')
-        color = client.get_string('/desktop/sugar/user/color')
+        nick = get_nick_name()
+        color = get_color()
 
         return nick is not '' and \
                color is not '' and \


### PR DESCRIPTION
This is required to run activities when Sugar shell is not installed.

Backported from: https://github.com/sugarlabs/sugar-toolkit-gtk3/commit/2f2b2d20d8ba8b6b94941dc0fed06a82c0f41a9f

Without this patch, I always get the following backtrace due to icon color is Null:
```
1487173709.532573 ERROR dbus.connection: Unable to set arguments (dbus.Dictionary({'activity_id': '84d7712155bb847842205c3082f8e3ee7bdb8748', 'title_set_by_user': '0', 'title': 'Jump Aktivit\xc3\xa1s', 'timestamp': 1487173709, 'activity': 'net.coderanger.olpc.JumpActivity', 'share-scope': 'private', 'keep': '0', 'icon-color': None, 'launch-times': '1487173709', 'mtime': '2017-02-15T16:48:29.531272', 'preview': '', 'mime_type': ''}, signature=None), '', False) according to signature u'a{sv}sb': <type 'exceptions.TypeError'>: Don't know which D-Bus type to use to encode type "NoneType"
Traceback (most recent call last):
  File "/usr/bin/sugar-activity", line 220, in <module>
    main()
  File "/usr/bin/sugar-activity", line 215, in main
    instance = create_activity_instance(activity_constructor, activity_handle)
  File "/usr/bin/sugar-activity", line 48, in create_activity_instance
    activity = constructor(handle)
  File "/usr/share/sugar/activitiesJump.activity/activity.py", line 23, in __init__
    activity.Activity.__init__(self, handle)
  File "/usr/lib/python2.7/site-packages/sugar/activity/activity.py", line 349, in __init__
    self._jobject = self._initialize_journal_object()
  File "/usr/lib/python2.7/site-packages/sugar/activity/activity.py", line 405, in _initialize_journal_object
    datastore.write(jobject)
  File "/usr/lib/python2.7/site-packages/sugar/datastore/datastore.py", line 385, in write
    transfer_ownership)
  File "/usr/lib/python2.7/site-packages/sugar/datastore/datastore.py", line 336, in _create_ds_entry
    transfer_ownership)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 70, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib/python2.7/site-packages/dbus/proxies.py", line 145, in __call__
    **keywords)
  File "/usr/lib/python2.7/site-packages/dbus/connection.py", line 641, in call_blocking
    message.append(signature=signature, *args)
TypeError: Don't know which D-Bus type to use to encode type "NoneType"
```